### PR TITLE
Fix: hero text escapes hero section stacking context (issue#12)

### DIFF
--- a/src/sections/hero.html
+++ b/src/sections/hero.html
@@ -1,4 +1,4 @@
-<section class="relative w-full flex justify-center items-start md:items-center md:mt-16">
+<section class="relative w-full flex justify-center items-start md:items-center md:mt-16 isolate">
     <div class="absolute z-10 w-full h-[50vh] md:h-screen flex justify-center items-center">
         <p class="text-center text-white text-balance font-semibold text-2xl md:text-5xl max-w-[60%] xl:w-[30%] translate-y-16 md:translate-y-0">We help you set focus and gain impact. By adding to the conversation, not to the noise.</p>
     </div>


### PR DESCRIPTION
## ✅ What
 
[Fix issue: Hero text escaping (or bleeding from) the hero section's stacking context](https://github.com/Group-3-Website-Project/Group-3-Website-Project/issues/12)
 
## 🤔 Why
 
To avoid bleeding hero text
 
## 👩‍🔬 How to validate
 
The hero text can't interfere with the hero section's siblings positioned children
 
## 🔖 Further reading
 
- [Jira task](https://trello.com/c/jSzCxzal/9-fix-bleeding-hero-text)
