### PR TITLE
Chore: Proper path of data store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 dist
 .idea
 .vscode
-./**/.DS_Store
+**/.DS_Store


### PR DESCRIPTION
## ✅ What

The PR updates the `.gitignore` file to ensure that `.DS_Store` files are ignored in all subdirectories, rather than just in the root level.

## 🤔 Why

This change prevents `.DS_Store` files from being tracked by Git, ensuring that they do not clutter the repository, especially in nested directories, standard on macOS systems.

## 👩‍🔬 How to validate

1. Verify that the `.gitignore` file now ignores `.DS_Store` files in all subdirectories, not just the root directory.
2. Test by creating a `.DS_Store` file in any subdirectory and confirm that it is ignored by Git (i.e., it does not show up when running `git status`).

## 🔖 Further reading

- [Trello card](https://trello.com/c/ZVQl8HDY/34-fix-working-on-requested-changes)
