### PR TITLE
Fix: fix big menu button on mobile issue

### DIFF
--- a/src/sections/header.html
+++ b/src/sections/header.html
@@ -11,7 +11,7 @@
         </a>
         
         <!-- Icon -->
-        <div id="icon" class="flex items-center justify-center w-16 h-10 bg-black cursor-pointer lg:hidden" style="background-color: var(--burger-menu-bg, black); clip-path: path('M1.80534 3.45135L0 19.722L14.0904 34.7824L51.342 37.4718L63.5391 19.5875L45.6178 0L1.80534 3.45135Z');">
+        <div id="icon" class="flex items-center justify-center w-16 h-10 bg-black cursor-pointer lg:hidden scale-75 lg:scale-1" style="background-color: var(--burger-menu-bg, black); clip-path: path('M1.80534 3.45135L0 19.722L14.0904 34.7824L51.342 37.4718L63.5391 19.5875L45.6178 0L1.80534 3.45135Z');">
             <img class="sm:w-30" src="assets/img/menu.svg" alt="the menu and close icon">
         </div>
 


### PR DESCRIPTION
## ✅ What
Added responsive scaling to mobile menu icon:
1. **New class**: Added `scale-75 lg:scale-1` to mobile menu icon container
2. **Visual adjustment**: Maintains icon size consistency across breakpoints

## 🤔 Why
0. **Fix issue#30**: https://github.com/Group-3-Website-Project/Group-3-Website-Project/issues/30
1. **Visual hierarchy**: Better proportionality between mobile and desktop views
2. **Responsive design**: Ensures consistent UI scaling with Tailwind breakpoints
3. **User experience**: Prevents abrupt size changes during viewport transitions

## 👩‍🔬 How to validate
1. **Responsive testing**:
   - Verify icon scales down to 75% size on mobile (max-width: 1023px)
   - Confirm full size at desktop breakpoint (min-width: 1024px)
2. **Visual inspection**:
   - Check smooth transition between breakpoints
   - Verify no layout shifts or overlapping elements
3. **Accessibility check**:
   - Ensure touch target remains adequate at smaller size
   - Verify icon remains visible against background

## 🔖 Further reading
- [Jira task](<link>)
