### PR TITLE
Fix: Links to the sections in nav dropdown

### DIFF
--- a/src/sections/about.html
+++ b/src/sections/about.html
@@ -1,4 +1,4 @@
-<div class="p-10 mt-8 md:p-17 lg:p-20">
+<div id="about-content" class="p-10 mt-8 md:p-17 lg:p-20">
     <p class="font-normal text-lg md:text-2xl lg:text-4xl break-words leading-tight">
 
         We are a Berlin-based communications agency specialising in helping companies and brands find their voice and

--- a/src/sections/header.html
+++ b/src/sections/header.html
@@ -1,5 +1,5 @@
 <div class="contents">
-    <nav class="sticky top-0 z-20 flex items-center justify-between p-4 mx-4">
+    <nav class="sticky top-0 z-30 flex items-center justify-between p-4 mx-4">
         <div class="flex flex-col font-normal sm:text-2xl">
             <p>DE</p>
             <p>EN</p>
@@ -21,7 +21,7 @@
 
         <ul class="flex-col items-end hidden font-sans lg:flex">
             <li class="hover:cursor-pointer">
-                <a href="#about">About</a>
+                <a href="#about-content">About</a>
             </li>
             <li class="hover:cursor-pointer">
                 <a href="#brand-strategy">Services</a>
@@ -35,12 +35,12 @@
         </ul>
     </nav>
   
-    <div id="menu" class="fixed inset-0 z-10 flex-col justify-end hidden w-full h-full isolate bg-gray-bg overflow-clip">
+    <div id="menu" class="fixed inset-0 z-20 flex-col justify-end hidden w-full h-full isolate bg-gray-bg overflow-clip">
         <img class="absolute -z-10 translate-y-[40%] md:translate-y-[20%]" src="assets\img\shapes.svg" alt="The shapes">
         <ul class="flex flex-col items-center w-full h-full font-sans text-3xl font-bold text-green-900 gap-14 md:text-4xl">
-            <li class="mt-36 sm:mt-22">About</li>
-            <li>Services</li> 
-            <li>References</li>
+            <li class="mt-36 sm:mt-22"><a href="#about-content">About</a></li>
+            <li><a href="#brand-strategy">Services</a></li> 
+            <li><a href="#acehotel">References</a></li>
             <li>Contact</li>
         </ul>
     </div>


### PR DESCRIPTION
## ✅ What

- Updated the `id` for the About section (`#about` → `#about-content`) to ensure proper linking.  
- Adjusted `z-index` values for navigation elements to improve layering and visibility (`z-20` → `z-30` for `<nav>`, `z-10` → `z-20` for `#menu`).  
- Wrapped navigation menu items in `<a>` tags for improved accessibility and better user experience.  

## 🤔 Why

- Fixes broken navigation links to ensure smooth scrolling to the correct sections.  
- Adjusts `z-index` to ensure the navigation bar appears above other content.  
- Enhances accessibility by making all navigation items clickable instead of plain text.  

## 👩‍🔬 How to validate

1. Open the website and check if clicking "About" in the navigation scrolls to the correct section.  
2. Verify that the sticky navigation bar remains on top of other content when scrolling.  
3. Open the mobile menu and confirm that all menu items are clickable and navigate properly.  

## 🔖 Further reading

- [Trello task](https://trello.com/c/iDE81zkP/42-fix-nav-dropdown-list-elements)
